### PR TITLE
Always pass options object to typeHasher() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ function typeHasher(hashFn, options){
       objType = objType.toLowerCase();
 
       if(objType !== 'object') {
-        if(typeHasher(hashFn)['_' + objType]) {
-          typeHasher(hashFn)['_' + objType](object);
+        if(typeHasher(hashFn, options)['_' + objType]) {
+          typeHasher(hashFn, options)['_' + objType](object);
         }else{
           throw new Error('Unknown object type "' + objType + '"');
         }
@@ -84,7 +84,7 @@ function typeHasher(hashFn, options){
     },
     _array: function(arr){
       return arr.forEach(function(el){
-        typeHasher(hashFn).dispatch(el);
+        typeHasher(hashFn, options).dispatch(el);
       });
     },
     _date: function(date){

--- a/test/index.js
+++ b/test/index.js
@@ -80,3 +80,12 @@ test('nested object values are hashed', function(assert){
   assert.equal(hash1, hash2, 'hashes are equal');
   assert.notEqual(hash1, hash3, 'different objects not equal');
 });
+
+test('array of nested object values are hashed', function(assert){
+  assert.plan(2);
+  var hash1 = hash({foo: [ {bar: true, bax: 1}, {bar: false, bax: 2} ] });
+  var hash2 = hash({foo: [ {bar: true, bax: 1}, {bar: false, bax: 2} ] });
+  var hash3 = hash({foo: [ {bar: false, bax: 2} ] });
+  assert.equal(hash1, hash2, 'hashes are equal');
+  assert.notEqual(hash1, hash3, 'different objects not equal');
+});


### PR DESCRIPTION
``` javascript
var obj = {
  key: 'val1',
  key2: 'val2',
  keys: [
    {
      key: 'val1',
      key2: 'val2'
    }
  ]
};
```

When I'm trying to create a hash from array of objects I'm getting following error:

```
TypeError: Cannot read property 'excludeValues' of undefined
  at /home/harri/Projects/repos/object-hash/index.js:79:22
  at Array.forEach (native)
  at _object (/home/harri/Projects/repos/object-hash/index.js:77:21)
  at Object.dispatch (/home/harri/Projects/repos/object-hash/index.js:60:48)
  at /home/harri/Projects/repos/object-hash/index.js:87:28
  at Array.forEach (native)
  at Object._array (/home/harri/Projects/repos/object-hash/index.js:86:18)
  at _object (/home/harri/Projects/repos/object-hash/index.js:70:44)
  at Object.dispatch (/home/harri/Projects/repos/object-hash/index.js:60:48)
  at /home/harri/Projects/repos/object-hash/index.js:80:41
```

Passing the options object to typeHasher() function solves the problem.

Best regards,
Harri
