### PR TITLE
add a .remove method to HashTable, decrementing counts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 0.9
   - 0.10
   - 0.11

--- a/lib/hashTable.js
+++ b/lib/hashTable.js
@@ -37,6 +37,32 @@ HashTable.prototype.add = function(/* values to be added */){
   return this;
 };
 
+HashTable.prototype.remove = function(/* values to be removed */){
+  var self = this;
+  var args = Array.prototype.slice.call(arguments, 0);
+  args.forEach(function(obj){
+    if(Object.prototype.toString.call(obj) === '[object Array]'){
+      obj.forEach(function(val){
+        self._removeObject(val);
+      });
+    }else{
+      self._removeObject(obj);
+    }
+  });
+  
+  return this;
+};
+
+HashTable.prototype._removeObject = function(object){
+  var hash = hasher(object, this.options),
+      count = this.getCount(hash);
+  if(count<=1) {
+    delete this._table[hash];
+  } else {
+    this._table[hash].count = count-1;
+  }
+};
+
 HashTable.prototype._addObject = function(object){
   var hash = hasher(object, this.options);
 
@@ -51,7 +77,7 @@ HashTable.prototype._addObject = function(object){
       count: 1
     }; 
   }
-}
+};
 
 HashTable.prototype.hasKey = function(key){
   return !!(this._table[key]);
@@ -85,4 +111,4 @@ HashTable.prototype.toArray = function(){
 HashTable.prototype.reset = function(){
   this._table = {};
   return this;
-}
+};

--- a/test/hashTable.js
+++ b/test/hashTable.js
@@ -110,3 +110,18 @@ test('.reset() should clear the hashTable', function(assert){
 });
 
 
+test('.remove() should decrement count', function(assert){
+  var hashTable = new hash.HashTable();
+  var hash1 = hash(obj1);
+  var hash3 = hash(obj3);
+  assert.plan(3);
+
+  hashTable.add(obj1, obj3);
+  hashTable.add(obj1);
+  hashTable.remove(obj1, obj3);
+
+  assert.equal(hashTable.getCount(hash1), 1, 'hash1 count = 1');
+  assert.equal(hashTable.getCount(hash3), 0, 'hash3 count = 0');
+  assert.equal(hashTable.hasKey(hash3), false, 'hash3 key is gone');
+  
+});


### PR DESCRIPTION
Adds a `.remove()` method to decrement counts, with same signature as `.add()`
+ add a couple missing semicolons
+ test for new feature
+ get build working by removing node v0.9 from build matrix
