### PR TITLE
Object types hashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ function typeHasher(hashFn, options, context){
           throw new Error('Unknown object type "' + objType + '"');
         }
       }else{
+        hashFn.update('object:');
         // TODO, add option for enumerating, for key in obj includePrototypeChain
         var keys = Object.keys(object).sort();
         return keys.forEach(function(key){
@@ -129,27 +130,28 @@ function typeHasher(hashFn, options, context){
       }
     },
     _array: function(arr){
+      hashFn.update('array:' + arr.length + ':');
       return arr.forEach(function(el){
         typeHasher(hashFn, options, context).dispatch(el);
       });
     },
     _date: function(date){
-      return hashFn.update(date.toJSON());
+      return hashFn.update('date:' + date.toJSON());
     },
     _boolean: function(bool){
-      return hashFn.update(bool.toString());
+      return hashFn.update('bool:' + bool.toString());
     },
     _string: function(string){
-      return hashFn.update(string);
+      return hashFn.update('string:' + string);
     },
     _function: function(fn){
-      return hashFn.update(fn.toString());
+      return hashFn.update('fn:' + fn.toString());
     },
     _number: function(number){
-      return hashFn.update(number.toString());
+      return hashFn.update('number:' + number.toString());
     },
     _xml: function(xml){
-      return hashFn.update(xml.toString());
+      return hashFn.update('xml:' + xml.toString());
     },
     _null: function(){
       return hashFn.update('Null');
@@ -158,7 +160,7 @@ function typeHasher(hashFn, options, context){
       return hashFn.update('Undefined');
     },
     _regexp: function(regex){
-      return hashFn.update(regex.toString());
+      return hashFn.update('regex:' + regex.toString());
     },
     _domwindow: function(){
       return hashFn.update('domwindow');

--- a/index.js
+++ b/index.js
@@ -210,8 +210,24 @@ function typeHasher(hashFn, options, context){
       hashFn.update('arraybuffer:');
       return typeHasher(hashFn, options, context).dispatch(new Uint8Array(arr));
     },
-    _domwindow: function(){
-      return hashFn.update('domwindow');
-    }
+    _domwindow: function(){ return hashFn.update('domwindow'); },
+    /* Node.js standard native objects */
+    _process: function(){ return hashFn.update('process'); },
+    _timer: function(){ return hashFn.update('timer'); },
+    _pipe: function(){ return hashFn.update('pipe'); },
+    _tcp: function(err){ return hashFn.update('tcp'); },
+    _udp: function(err){ return hashFn.update('udp'); },
+    _tty: function(err){ return hashFn.update('tty'); },
+    _statwatcher: function(err){ return hashFn.update('statwatcher'); },
+    _securecontext: function(err){ return hashFn.update('securecontext'); },
+    _connection: function(err){ return hashFn.update('connection'); },
+    _zlib: function(err){ return hashFn.update('zlib'); },
+    _context: function(err){ return hashFn.update('context'); },
+    _nodescript: function(err){ return hashFn.update('nodescript'); },
+    _httpparser: function(err){ return hashFn.update('httpparser'); },
+    _dataview: function(err){ return hashFn.update('dataview'); },
+    _signal: function(err){ return hashFn.update('signal'); },
+    _fsevent: function(err){ return hashFn.update('fsevent'); },
+    _tlswrap: function(err){ return hashFn.update('tlswrap'); }
   };
 }

--- a/index.js
+++ b/index.js
@@ -110,6 +110,11 @@ function typeHasher(hashFn, options, context){
       } else {
         context.push(object);
       }
+      
+      if (typeof Buffer != 'undefined' && Buffer.isBuffer && Buffer.isBuffer(object)) {
+        hashFn.update('buffer:');
+        return hashFn.update(object);
+      }
 
       if(objType !== 'object') {
         if(typeHasher(hashFn, options, context)['_' + objType]) {
@@ -161,6 +166,46 @@ function typeHasher(hashFn, options, context){
     },
     _regexp: function(regex){
       return hashFn.update('regex:' + regex.toString());
+    },
+    _uint8array: function(arr){
+      hashFn.update('uint8array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _uint8clampedarray: function(arr){
+      hashFn.update('uint8clampedarray:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _int8array: function(arr){
+      hashFn.update('uint8array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _uint16array: function(arr){
+      hashFn.update('uint16array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _int16array: function(arr){
+      hashFn.update('uint16array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _uint32array: function(arr){
+      hashFn.update('uint32array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _int32array: function(arr){
+      hashFn.update('uint32array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _float32array: function(arr){
+      hashFn.update('float32array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _float64array: function(arr){
+      hashFn.update('float64array:');
+      return typeHasher(hashFn, options, context).dispatch(Array.prototype.slice.call(arr));
+    },
+    _arraybuffer: function(arr){
+      hashFn.update('arraybuffer:');
+      return typeHasher(hashFn, options, context).dispatch(new Uint8Array(arr));
     },
     _domwindow: function(){
       return hashFn.update('domwindow');

--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ function typeHasher(hashFn, options, context){
     _date: function(date){
       return hashFn.update('date:' + date.toJSON());
     },
+    _error: function(err){
+      return hashFn.update('error:' + err.toString());
+    },
     _boolean: function(bool){
       return hashFn.update('bool:' + bool.toString());
     },

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function typeHasher(hashFn, options, context){
         context.push(object);
       }
       
-      if (typeof Buffer != 'undefined' && Buffer.isBuffer && Buffer.isBuffer(object)) {
+      if (typeof Buffer !== 'undefined' && Buffer.isBuffer && Buffer.isBuffer(object)) {
         hashFn.update('buffer:');
         return hashFn.update(object);
       }
@@ -215,19 +215,19 @@ function typeHasher(hashFn, options, context){
     _process: function(){ return hashFn.update('process'); },
     _timer: function(){ return hashFn.update('timer'); },
     _pipe: function(){ return hashFn.update('pipe'); },
-    _tcp: function(err){ return hashFn.update('tcp'); },
-    _udp: function(err){ return hashFn.update('udp'); },
-    _tty: function(err){ return hashFn.update('tty'); },
-    _statwatcher: function(err){ return hashFn.update('statwatcher'); },
-    _securecontext: function(err){ return hashFn.update('securecontext'); },
-    _connection: function(err){ return hashFn.update('connection'); },
-    _zlib: function(err){ return hashFn.update('zlib'); },
-    _context: function(err){ return hashFn.update('context'); },
-    _nodescript: function(err){ return hashFn.update('nodescript'); },
-    _httpparser: function(err){ return hashFn.update('httpparser'); },
-    _dataview: function(err){ return hashFn.update('dataview'); },
-    _signal: function(err){ return hashFn.update('signal'); },
-    _fsevent: function(err){ return hashFn.update('fsevent'); },
-    _tlswrap: function(err){ return hashFn.update('tlswrap'); }
+    _tcp: function(){ return hashFn.update('tcp'); },
+    _udp: function(){ return hashFn.update('udp'); },
+    _tty: function(){ return hashFn.update('tty'); },
+    _statwatcher: function(){ return hashFn.update('statwatcher'); },
+    _securecontext: function(){ return hashFn.update('securecontext'); },
+    _connection: function(){ return hashFn.update('connection'); },
+    _zlib: function(){ return hashFn.update('zlib'); },
+    _context: function(){ return hashFn.update('context'); },
+    _nodescript: function(){ return hashFn.update('nodescript'); },
+    _httpparser: function(){ return hashFn.update('httpparser'); },
+    _dataview: function(){ return hashFn.update('dataview'); },
+    _signal: function(){ return hashFn.update('signal'); },
+    _fsevent: function(){ return hashFn.update('fsevent'); },
+    _tlswrap: function(){ return hashFn.update('tlswrap'); }
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ test('hashes non-object types', function(assert){
 });
 
 test('hashes special object types', function(assert){
-  assert.plan(8);
+  assert.plan(9);
   var dt = new Date();
   dt.setDate(dt.getDate() + 1);
 
@@ -42,6 +42,7 @@ test('hashes special object types', function(assert){
   assert.ok(validSha1.test(hash(Number.NaN)), 'hash NaN');
   assert.ok(validSha1.test(hash({ foo: undefined })), 'hash Undefined value');
   assert.ok(validSha1.test(hash(new RegExp())), 'hash regex');
+  assert.ok(validSha1.test(hash(new Error())), 'hash error');
 });
 
 test('hashes a simple object', function(assert){

--- a/test/index.js
+++ b/test/index.js
@@ -126,3 +126,17 @@ test("recursive handling tracks identity", function(assert) {
   hash2.k2.r2 = hash2.k1;
   assert.notEqual(hash(hash1), hash(hash2), "order of recursive objects should matter");
 });
+
+test("null and 'Null' string produce different hashes", function(assert) {
+  assert.plan(1);
+  var hash1 = hash({foo: null});
+  var hash2 = hash({foo: 'Null'});
+  assert.notEqual(hash1, hash2, "null and 'Null' should not produce identical hashes");
+});
+
+test("object types are hashed", function(assert) {
+  assert.plan(1);
+  var hash1 = hash({foo: 'bar'});
+  var hash2 = hash(['foo', 'bar']);
+  assert.notEqual(hash1, hash2, "arrays and objects should not produce identical hashes");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -142,13 +142,14 @@ test("object types are hashed", function(assert) {
   assert.notEqual(hash1, hash2, "arrays and objects should not produce identical hashes");
 });
 
-if (typeof Buffer != 'undefined')
+if (typeof Buffer !== 'undefined') {
 test("Buffers can be hashed", function(assert) {
   assert.plan(1);
   assert.ok(validSha1.test(hash(new Buffer('Banana'))), 'hashes Buffers');
 });
+}
 
-if (typeof Uint8Array != 'undefined')
+if (typeof Uint8Array !== 'undefined') {
 test("Typed arrays can be hashed", function(assert) {
   assert.plan(10);
   
@@ -163,3 +164,4 @@ test("Typed arrays can be hashed", function(assert) {
   assert.ok(validSha1.test(hash(new Uint8ClampedArray([1,2,3,4]))), 'hashes Uint8ClampedArray');
   assert.ok(validSha1.test(hash(new Uint8Array([1,2,3,4]).buffer)), 'hashes ArrayBuffer');
 });
+}

--- a/test/index.js
+++ b/test/index.js
@@ -140,3 +140,25 @@ test("object types are hashed", function(assert) {
   var hash2 = hash(['foo', 'bar']);
   assert.notEqual(hash1, hash2, "arrays and objects should not produce identical hashes");
 });
+
+if (typeof Buffer != 'undefined')
+test("Buffers can be hashed", function(assert) {
+  assert.plan(1);
+  assert.ok(validSha1.test(hash(new Buffer('Banana'))), 'hashes Buffers');
+});
+
+if (typeof Uint8Array != 'undefined')
+test("Typed arrays can be hashed", function(assert) {
+  assert.plan(10);
+  
+  assert.ok(validSha1.test(hash(new Uint8Array([1,2,3,4]))), 'hashes Uint8Array');
+  assert.ok(validSha1.test(hash(new  Int8Array([1,2,3,4]))), 'hashes  Int8Array');
+  assert.ok(validSha1.test(hash(new Uint16Array([1,2,3,4]))), 'hashes Uint16Array');
+  assert.ok(validSha1.test(hash(new  Int16Array([1,2,3,4]))), 'hashes  Int16Array');
+  assert.ok(validSha1.test(hash(new Uint32Array([1,2,3,4]))), 'hashes Uint32Array');
+  assert.ok(validSha1.test(hash(new  Int32Array([1,2,3,4]))), 'hashes  Int32Array');
+  assert.ok(validSha1.test(hash(new Float32Array([1,2,3,4]))), 'hashes Float32Array');
+  assert.ok(validSha1.test(hash(new Float64Array([1,2,3,4]))), 'hashes Float64Array');
+  assert.ok(validSha1.test(hash(new Uint8ClampedArray([1,2,3,4]))), 'hashes Uint8ClampedArray');
+  assert.ok(validSha1.test(hash(new Uint8Array([1,2,3,4]).buffer)), 'hashes ArrayBuffer');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -58,7 +58,7 @@ test('hashes identical objects with different key ordering', function(assert){
   assert.notEqual(hash1, hash3, 'different objects not equal');
 });
 
-test('only hashes object keys when excludeValues option is set', function(assert){
+test('hashes only object keys when excludeValues option is set', function(assert){
   assert.plan(2);
   var hash1 = hash({foo: false, bar: 'OK'}, { excludeValues: true });
   var hash2 = hash({foo: true, bar: 'NO'}, { excludeValues: true });


### PR DESCRIPTION
* Hash types of values along with values themselves, e.g. distinguishing `"Null"` from `null`, `["a", "b"]` from `{"a": "b"}` (obviously, this changes the hash values of almost all objects)
* Support hashing of node.js Buffer, ArrayBuffer, typed array JS objects
* Handle known Node.js internal objects (in the same way as DOMWindow) by feeding the type name to the hashing algorithm (This may or may not be considered a fix of #13 – the code *runs*, but no semantic information about the `Timer` object is preserved)

For details, see the individual commit messages; Again, feel free to cherry-pick any of these commits.