### PR TITLE
Use UTF-8 encoding for hashing strings by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function typeHasher(hashFn, options, context){
         // TODO, add option for enumerating, for key in obj includePrototypeChain
         var keys = Object.keys(object).sort();
         return keys.forEach(function(key){
-          hashFn.update(key);
+          hashFn.update(key, 'utf8');
           if(!options.excludeValues) {
             typeHasher(hashFn, options, context).dispatch(object[key]);
           }
@@ -144,22 +144,22 @@ function typeHasher(hashFn, options, context){
       return hashFn.update('date:' + date.toJSON());
     },
     _error: function(err){
-      return hashFn.update('error:' + err.toString());
+      return hashFn.update('error:' + err.toString(), 'utf8');
     },
     _boolean: function(bool){
       return hashFn.update('bool:' + bool.toString());
     },
     _string: function(string){
-      return hashFn.update('string:' + string);
+      return hashFn.update('string:' + string, 'utf8');
     },
     _function: function(fn){
-      return hashFn.update('fn:' + fn.toString());
+      return hashFn.update('fn:' + fn.toString(), 'utf8');
     },
     _number: function(number){
       return hashFn.update('number:' + number.toString());
     },
     _xml: function(xml){
-      return hashFn.update('xml:' + xml.toString());
+      return hashFn.update('xml:' + xml.toString(), 'utf8');
     },
     _null: function(){
       return hashFn.update('Null');
@@ -168,7 +168,7 @@ function typeHasher(hashFn, options, context){
       return hashFn.update('Undefined');
     },
     _regexp: function(regex){
-      return hashFn.update('regex:' + regex.toString());
+      return hashFn.update('regex:' + regex.toString(), 'utf8');
     },
     _uint8array: function(arr){
       hashFn.update('uint8array:');

--- a/test/index.js
+++ b/test/index.js
@@ -142,6 +142,14 @@ test("object types are hashed", function(assert) {
   assert.notEqual(hash1, hash2, "arrays and objects should not produce identical hashes");
 });
 
+test("utf8 strings are hashed correctly", function(assert) {
+  assert.plan(1);
+  var hash1 = hash('\u03c3'); // cf 83 in utf8
+  var hash2 = hash('\u01c3'); // c7 83 in utf8
+  console.log('!!', hash1, hash2);
+  assert.notEqual(hash1, hash2, "different strings with similar utf8 encodings should produce different hashes");
+});
+
 if (typeof Buffer !== 'undefined') {
 test("Buffers can be hashed", function(assert) {
   assert.plan(1);


### PR DESCRIPTION
Whenever non-ASCII characters might be passed to the hash function, specify the encoding (utf-8) instead of using the default binary encoding.

This also makes the behaviours in the browser (currently using legacy versions of `crypto-browserify`) and on Node.js match.

This fixes #18.