### PR TITLE
Added bower.json so the package can be added to the Bower repository

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "object-hash",
+  "homepage": "https://github.com/puleos/object-hash",
+  "description": "Generate hashes from javascript objects in node and the browser",
+  "main": "index.js",
+  "author": "Scott Puleo <puleos@gmail.com>",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
We use object-hash browser-side, and would like to use bower to install object-hash.
To add object-hash to the bower repository, please pull this request and run

`bower register object-hash git://github.com/puleos/object-hash.git`

See http://bower.io/docs/creating-packages/#register for more details.