### PR TITLE
Fix bower.json for browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "object-hash",
   "homepage": "https://github.com/puleos/object-hash",
   "description": "Generate hashes from javascript objects in node and the browser",
-  "main": "index.js",
+  "main": "dist/object_hash.js",
   "author": "Scott Puleo <puleos@gmail.com>",
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
The old bower.json was refering to wrong script for browsers `index.js`.
The right is `dist/object_hash.js`