### PR TITLE
Add section main into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "author": "Scott Puleo <puleos@gmail.com>",
   "license": "MIT",
+  "main": "dist/object_hash.js",
   "devDependencies": {
     "browserify": "^13.0.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Hi, guys!

I've used your package for web (bundle my app with webpack) and it works awesome.
But I've got an error while using this `object-hash` with react-native:
```bash
Unable to resolve module crypto from /Users/isnifer/www/tipsi-react-app/node_modules/object-hash/index.js: Module does not exist in the module map or in these directories:
```
But this problem can be solved by adding section "main" into package.json

@puleos @addaleax 

P.S.: also, please update module in npm after that.