### PR TITLE
Add a stand-alone dockerized node service for object-hash

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  node:
+    image: "node:8.6-alpine"
+    user: "node"
+    working_dir: /home/node/app
+    restart: always
+    volumes:
+      - ./:/home/node/app:ro
+    ports:
+      - 8081:8081
+    command: "npm start"

--- a/docker/node.js
+++ b/docker/node.js
@@ -1,0 +1,26 @@
+var http = require('http')
+var hash = require('object-hash')
+var url = require('url')
+
+http.createServer(function (request, response) {
+  let url_parts = url.parse(request.url, true)
+
+  // Chrome requests the favicon. Rather than crash, just return nothing.
+  if(url_parts.query === undefined || url_parts.query.obj_to_hash === undefined) {
+    return
+  }
+
+  let o = ""
+  try {
+    o = JSON.parse(url_parts.query.obj_to_hash)
+  } catch(e) {
+    console.warn('Provided obj_to_hash is not valid JSON; defaulting to using it as a string')
+    o = url_parts.query.obj_to_hash
+  }
+  
+  // TODO: accept options from parameters
+  response.end(hash(o, {respectType: true, unorderedArrays: true, unorderedSets: true}))
+}).listen(8081)
+
+// Console will print the message
+console.log('Server running at http://127.0.0.1:8081/')

--- a/docker/package-lock.json
+++ b/docker/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "object-hash-as-node",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "object-hash": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
+      "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    }
+  }
+}

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "object-hash-as-node",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "object-hash": "1.1.8",
+    "url": "^0.11.0"
+  },
+  "scripts": {
+    "start": "node node.js"
+  }
+}


### PR DESCRIPTION
I realized that this tool would be helpful to call from tools such as JMeter and Postman. Of course, since JMeter is written in Java, the container for that would be built primarily for Java. Having a service just for object-hash seemed to make sense.

This is not the best node code, but it is a good start.