### PR TITLE
Add an option for exclude specific keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ function applyDefaults(object, options){
   options.unorderedArrays = options.unorderedArrays !== true ? false : true; // default to false
   options.unorderedSets = options.unorderedSets === false ? false : true; // default to false
   options.replacer = options.replacer || undefined;
+  options.excludeKeys = options.excludeKeys || undefined;
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');
@@ -217,6 +218,17 @@ function typeHasher(options, writeTo, context){
         }
       }else{
         var keys = Object.keys(object).sort();
+        // Exclude specified keys
+        if (options.excludeKeys) {
+          var numberOfExcludedKeys = options.excludeKeys.length;
+          for (var index = 0; index < numberOfExcludedKeys; ++index) {
+            var keyIndex = keys.indexOf(options.excludeKeys[index]);
+            if (keyIndex > -1) {
+              keys.splice(keyIndex, 1);
+            }
+          }
+        }
+        
         // Make sure to incorporate special properties, so
         // Types with different prototypes will produce
         // a different hash and objects derived from

--- a/index.js
+++ b/index.js
@@ -218,17 +218,6 @@ function typeHasher(options, writeTo, context){
         }
       }else{
         var keys = Object.keys(object).sort();
-        // Exclude specified keys
-        if (options.excludeKeys) {
-          var numberOfExcludedKeys = options.excludeKeys.length;
-          for (var index = 0; index < numberOfExcludedKeys; ++index) {
-            var keyIndex = keys.indexOf(options.excludeKeys[index]);
-            if (keyIndex > -1) {
-              keys.splice(keyIndex, 1);
-            }
-          }
-        }
-        
         // Make sure to incorporate special properties, so
         // Types with different prototypes will produce
         // a different hash and objects derived from
@@ -243,6 +232,10 @@ function typeHasher(options, writeTo, context){
         write('object:' + keys.length + ':');
         var self = this;
         return keys.forEach(function(key){
+          if (options.excludeKeys) {
+            if ( !options.excludeKeys(key))
+              return;
+          }
           self.dispatch(key);
           write(':');
           if(!options.excludeValues) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -43,6 +43,7 @@ Generate a hash from any object or type.  Defaults to sha1 with hex encoding.
    i.e. including typed arrays, Sets, Maps, etc. default: false
 *  `unorderedSets` {true|false} Sort `Set` and `Map` instances before hashing, i.e. make
    `hash(new Set([1, 2])) == hash(new Set([2, 1]))` return `true`. default: true
+*  `excludeKeys` optional function for exclude specific key(s) from hashing, if returns false then exclude from hash. default: include all keys   
 
 ## hash.sha1(value);
 Hash using the sha1 algorithm.
@@ -116,6 +117,18 @@ hash(michael, { excludeValues: true });
 // 48f370a772c7496f6c9d2e6d92e920c87dd00a5c
 hash.keys(bob);
 // 48f370a772c7496f6c9d2e6d92e920c87dd00a5c
+
+/***
+ * hash object, ignore specific keys
+ */
+hash(peter, { excludeKeys: function(key) {
+    if ( key === 'friends') {
+      return false;
+    }
+    return true;
+  }
+});
+// 66b7d7e64871aa9fda1bdc8e88a28df797648d80
 
 /***
  * md5 base64 encoding


### PR DESCRIPTION
We need to exclude some keys from hashing process . We tried to use replacer function for this purpose but unlike JSON.stringfy replacer your function doesn't include key property.