### PR TITLE
copy options instead of mutating when applying defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,22 +58,25 @@ var hashes = crypto.getHashes ? crypto.getHashes().slice() : ['sha1', 'md5'];
 hashes.push('passthrough');
 var encodings = ['buffer', 'hex', 'binary', 'base64'];
 
-function applyDefaults(object, options){
-  options = options || {};
-  options.algorithm = options.algorithm || 'sha1';
-  options.encoding = options.encoding || 'hex';
-  options.excludeValues = options.excludeValues ? true : false;
+function applyDefaults(object, sourceOptions){
+  sourceOptions = sourceOptions || {};
+
+  // create a copy rather than mutating
+  var options = {};
+  options.algorithm = sourceOptions.algorithm || 'sha1';
+  options.encoding = sourceOptions.encoding || 'hex';
+  options.excludeValues = sourceOptions.excludeValues ? true : false;
   options.algorithm = options.algorithm.toLowerCase();
   options.encoding = options.encoding.toLowerCase();
-  options.ignoreUnknown = options.ignoreUnknown !== true ? false : true; // default to false
-  options.respectType = options.respectType === false ? false : true; // default to true
-  options.respectFunctionNames = options.respectFunctionNames === false ? false : true;
-  options.respectFunctionProperties = options.respectFunctionProperties === false ? false : true;
-  options.unorderedArrays = options.unorderedArrays !== true ? false : true; // default to false
-  options.unorderedSets = options.unorderedSets === false ? false : true; // default to false
-  options.unorderedObjects = options.unorderedObjects === false ? false : true; // default to true
-  options.replacer = options.replacer || undefined;
-  options.excludeKeys = options.excludeKeys || undefined;
+  options.ignoreUnknown = sourceOptions.ignoreUnknown !== true ? false : true; // default to false
+  options.respectType = sourceOptions.respectType === false ? false : true; // default to true
+  options.respectFunctionNames = sourceOptions.respectFunctionNames === false ? false : true;
+  options.respectFunctionProperties = sourceOptions.respectFunctionProperties === false ? false : true;
+  options.unorderedArrays = sourceOptions.unorderedArrays !== true ? false : true; // default to false
+  options.unorderedSets = sourceOptions.unorderedSets === false ? false : true; // default to false
+  options.unorderedObjects = sourceOptions.unorderedObjects === false ? false : true; // default to true
+  options.replacer = sourceOptions.replacer || undefined;
+  options.excludeKeys = sourceOptions.excludeKeys || undefined;
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,20 @@ describe('hash', function() {
     }, 'bad encoding');
   });
 
+  it('copies options rather than mutating', function() {
+    var options = {
+      algorithm: 'MD5',
+      encoding: 'HEX'
+    }
+
+    hash({foo: 'bar'}, options)
+
+    assert.deepEqual(options, {
+      algorithm: 'MD5',
+      encoding: 'HEX'
+    }, 'source options have neither been modified nor added to')
+  });
+
   it('hashes a simple object', function() {
     assert.ok(validSha1.test(hash({foo: 'bar', bar: 'baz'})), 'hash object');
   });


### PR DESCRIPTION
I ran into an issue where the `options` object was frozen with `Object.freeze()` which object-hash throws an error on because it mutates the `options` parameter.  Here's the replay showing the issue:

```
> const hasher = require('object-hash')
undefined
> hasher('some text', Object.freeze({}))
TypeError: Cannot add property algorithm, object is not extensible
    at applyDefaults (/Users/step9581/node_modules/object-hash/index.js:63:21)
    at objectHash (/Users/step9581/node_modules/object-hash/index.js:31:13)
```

This PR copies rather than mutates the `options` parameter.  A test is included to show that `algorithm` and `encoding` remain capitalized and no other options are added after the function call.  