### PR TITLE
object-hash:Removed PhantomJS Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "6"
-  - "8"
+  - 6
+  - 8
+  - 10
+  - 11
 sudo: false
 # use g++-4.8 for karma
 cache:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,7 +55,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS', 'Firefox'],
+    browsers: ['ChromeHeadless', 'Firefox'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -35,13 +35,11 @@
     "gulp-uglify": "^1.5.1",
     "jshint": "^2.8.0",
     "jshint-stylish": "^2.1.0",
-    "karma": "^0.13.15",
-    "karma-chrome-launcher": "^0.2.2",
+    "karma": "^3.0.0",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.1",
-    "karma-phantomjs-launcher": "^0.2.1",
-    "mocha": "^2.3.4",
-    "phantomjs": "^1.9.19"
+    "mocha": "^2.3.4"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
PhantomJS is an unmaintained project, removed the phantomjs dependency from the devdependency in package.json. Added chrome headless support in karma.conf.js and removed the phantomjs support.
Updated the karma and karma-chrome-launcher version in package.json as the earlier version used were very old.
Updated the node version to latest from the travis.yml as the earlier versions used were very old.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>