### PR TITLE
added excludeUndefinedValues to options

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ function applyDefaults(object, options){
   options.unorderedObjects = options.unorderedObjects === false ? false : true; // default to true
   options.replacer = options.replacer || undefined;
   options.excludeKeys = options.excludeKeys || undefined;
+  options.excludeUndefinedValues = options.excludeUndefinedValues !== true  ? false : true; // default to false
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');
@@ -235,6 +236,10 @@ function typeHasher(options, writeTo, context){
 
         if (options.excludeKeys) {
           keys = keys.filter(function(key) { return !options.excludeKeys(key); });
+        }
+
+        if (options.excludeUndefinedValues) {
+          keys = keys.filter(function(key) { return object[key] !== undefined; });
         }
 
         write('object:' + keys.length + ':');

--- a/readme.markdown
+++ b/readme.markdown
@@ -46,6 +46,7 @@ Generate a hash from any object or type.  Defaults to sha1 with hex encoding.
    `hash(new Set([1, 2])) == hash(new Set([2, 1]))` return `true`. default: true
 *  `unorderedObjects` {true|false} Sort objects before hashing, i.e. make `hash({ x: 1, y: 2 }) === hash({ y: 2, x: 1 })`. default: true
 *  `excludeKeys` optional function for exclude specific key(s) from hashing, if returns true then exclude from hash. default: include all keys
+*  `excludeUndefinedValues` {true|false} Exclude undefined properties when hashing. default: false
 
 ## hash.sha1(value);
 Hash using the sha1 algorithm.

--- a/test/index.js
+++ b/test/index.js
@@ -268,6 +268,14 @@ describe('hash', function() {
     assert.equal(ha, hb, 'Hashing should ignore key `b`');
   });
 
+  it('excludeUndefinedValues works', function() {
+    var ha, hb;
+    ha = hash({a: 1, b: undefined}, { excludeUndefinedValues: true });
+    hb = hash({a: 1}, { excludeUndefinedValues: true });
+
+    assert.equal(ha, hb, 'Hashing should ignore key `b`');
+  });
+
   if (typeof Set !== 'undefined') {
     it('unorderedSets = false', function() {
       var opt = { unorderedSets: false };


### PR DESCRIPTION
we JSON.stringify() the object after the hash.
Assuming that undefined values are not reflected in JSON, we would like to skip undefined values when we create hash of the object.
