### PR TITLE
Fix the crash when hashing an `async` function

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,9 @@ gulp.task('dist', function(){
       .pipe(uglify())
       .pipe(gulp.dest('./dist')),
     gulp.src([paths.tests])
+      // Hack: browserify seems to not support async-await.
+      // It's probably better to replace gulp-browserify altogether instead.
+      .pipe(replace(/async function/g, 'function'))
       .pipe(browserify())
       .pipe(rename('object_hash_test.js'))
       .pipe(gulp.dest('./dist'))

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ function typeHasher(options, writeTo, context){
         return write(object);
       }
 
-      if(objType !== 'object' && objType !== 'function') {
+      if(objType !== 'object' && objType !== 'function' && objType !== 'asyncfunction') {
         if(this['_' + objType]) {
           this['_' + objType](object);
         } else if (options.ignoreUnknown) {

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,18 @@ describe('hash', function() {
     assert.notEqual(c,d, 'changing a property in the prototype changes the hash');
   });
 
+  it('distinguishes async functions based on their properties', function() {
+    var a, b;
+    
+    async function Foo() {}
+    a = hash(Foo);
+
+    Foo.foo = 22;
+    b = hash(Foo);
+
+    assert.notEqual(a,b, 'adding a property changes the hash');
+  });
+
   it('Distinguish objects based on their type', function() {
 
     function Foo() {}

--- a/test/index.js
+++ b/test/index.js
@@ -221,8 +221,18 @@ describe('hash', function() {
 
   it('distinguishes async functions based on their properties', function() {
     var a, b;
-    
-    async function Foo() {}
+
+    var Foo;
+
+    try {
+      Foo = eval('async function Foo() {}; Foo');
+    } catch (err) {
+      if (err.name === 'SyntaxError')
+        return this.skip('Not available on Node 6');
+      else
+        throw err;
+    }
+
     a = hash(Foo);
 
     Foo.foo = 22;

--- a/test/types.js
+++ b/test/types.js
@@ -8,11 +8,13 @@ var validSha1 = /^[0-9a-f]{40}$/i;
 describe('hash()ing different types', function() {
   it('hashes non-object types', function() {
     var func = function(a){ return a + 1; };
+    var asyncFunc = async function(a){ return a + 1; };
     assert.ok(validSha1.test(hash('Shazbot!')), 'hash string');
     assert.ok(validSha1.test(hash(42)), 'hash number');
     assert.ok(validSha1.test(hash(NaN)), 'hash bool');
     assert.ok(validSha1.test(hash(true)), 'hash bool');
     assert.ok(validSha1.test(hash(func)), 'hash function');
+    assert.ok(validSha1.test(hash(asyncFunc)), 'hash async function');
   });
 
   it('hashes special object types', function() {

--- a/test/types.js
+++ b/test/types.js
@@ -8,7 +8,13 @@ var validSha1 = /^[0-9a-f]{40}$/i;
 describe('hash()ing different types', function() {
   it('hashes non-object types', function() {
     var func = function(a){ return a + 1; };
-    var asyncFunc = async function(a){ return a + 1; };
+    var asyncFunc;
+    try {
+      asyncFunc = eval('async function(a) { return a + 1; }');
+    } catch (err) {
+      if (err.name === 'SyntaxError') asyncFunc = func;
+      else throw err;
+    }
     assert.ok(validSha1.test(hash('Shazbot!')), 'hash string');
     assert.ok(validSha1.test(hash(42)), 'hash number');
     assert.ok(validSha1.test(hash(NaN)), 'hash bool');
@@ -36,7 +42,7 @@ describe('hash()ing different types', function() {
     if (typeof process !== 'undefined') {
       assert.ok(validSha1.test(hash(process)), 'hash process');
     }
-    
+
     var timer = setTimeout(function() {}, 0);
     assert.ok(validSha1.test(hash(timer)), 'hash timer');
   });
@@ -55,7 +61,7 @@ describe('hash()ing different types', function() {
 
   if (typeof Uint8Array !== 'undefined') {
     it("Typed arrays can be hashed", function() {
-      
+
       assert.ok(validSha1.test(hash(new Uint8Array([1,2,3,4]))), 'hashes Uint8Array');
       assert.ok(validSha1.test(hash(new  Int8Array([1,2,3,4]))), 'hashes  Int8Array');
       assert.ok(validSha1.test(hash(new Uint16Array([1,2,3,4]))), 'hashes Uint16Array');
@@ -132,7 +138,7 @@ describe('hash()ing different types', function() {
     // Self check; did we really hash all the types?
     assert.equal(no, types.length);
   });
-  
+
   it("Builtin types might result in identical hashes with respectFunctionNames = false", function() {
     var hashcount = {};
     var types = [Object, Date, Number, String, Function, RegExp,
@@ -161,14 +167,14 @@ describe('hash()ing different types', function() {
     // Self check; did we really hash all the types?
     assert.equal(no, types.length);
   });
-  
+
   it("Functions with identical bodies and different names result in identical hashes with respectFunctionNames = false", function() {
     var fn1 = function a() {};
     var fn2 = function b() {};
     var toStringDummy = function() { return '...'; };
     fn1.toString = toStringDummy;
     fn2.toString = toStringDummy;
-    
+
     var h1 = hash(fn1, { respectFunctionNames: false });
     var h2 = hash(fn2, { respectFunctionNames: false });
     assert.strictEqual(h1, h2);


### PR DESCRIPTION
Fixes #67.

This code will no longer crash:

```
objectHash(async function foo () {})
```