### PR TITLE
refactor: remove unnecessary clutter from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "prepublish": "gulp dist"
   },
   "author": "Scott Puleo <puleos@gmail.com>",
+  "files": [
+    "index.js",
+    "dist/object_hash.js"
+  ],
   "license": "MIT",
   "devDependencies": {
     "browserify": "^16.2.3",


### PR DESCRIPTION
This makes it so that only the necessary files get published to npm, reducing download sizes.