### PR TITLE
feat: add bigint support

### DIFF
--- a/index.js
+++ b/index.js
@@ -406,6 +406,9 @@ function typeHasher(options, writeTo, context){
         'Use "options.replacer" or "options.ignoreUnknown"\n');
     },
     _domwindow: function() { return write('domwindow'); },
+    _bigint: function(number){
+      return write('bigint:' + number.toString());
+    },
     /* Node.js standard native objects */
     _process: function() { return write('process'); },
     _timer: function() { return write('timer'); },

--- a/test/types.js
+++ b/test/types.js
@@ -110,6 +110,14 @@ describe('hash()ing different types', function() {
     });
   }
 
+  if (typeof BigInt !== 'undefined') {
+    it("BigInts can be hashed", function() {
+      assert.ok(function() {
+        validSha1.test(hash(BigInt(42)))
+      }, 'hashes BigInts');
+    });
+  }
+
   it("Builtin types themselves can be hashed", function() {
     var hashcount = {};
     var types = [Object, Date, Number, String, Function, RegExp,
@@ -120,6 +128,7 @@ describe('hash()ing different types', function() {
     if (typeof Map !== 'undefined') types.push(Map);
     if (typeof Symbol !== 'undefined') types.push(Symbol);
     if (typeof Uint8Array !== 'undefined') types.push(Uint8Array);
+    if (typeof BigInt !== 'undefined') types.push(BigInt);
 
     // Hash each type
     for (var idx in types) {
@@ -149,6 +158,7 @@ describe('hash()ing different types', function() {
     if (typeof Map !== 'undefined') types.push(Map);
     if (typeof Symbol !== 'undefined') types.push(Symbol);
     if (typeof Uint8Array !== 'undefined') types.push(Uint8Array);
+    if (typeof BigInt !== 'undefined') types.push(BigInt);
 
     // Hash each type
     for (var idx in types) {


### PR DESCRIPTION
Adds support for bigints. Currently an error is thrown when passing `BigInt`s:

```
this[(\"_\" + type)] is not a function
```
This adds the corresponding method for the `bigint` type, which uses the `bigint.toString()` 

Let me know if there's a need for any changes.