### PR TITLE
Javascript unsigned signed typed arrays return same hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ function typeHasher(options, writeTo, context){
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _int8array: function(arr){
-      write('uint8array:');
+      write('int8array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _uint16array: function(arr){
@@ -356,7 +356,7 @@ function typeHasher(options, writeTo, context){
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _int16array: function(arr){
-      write('uint16array:');
+      write('int16array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _uint32array: function(arr){
@@ -364,7 +364,7 @@ function typeHasher(options, writeTo, context){
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _int32array: function(arr){
-      write('uint32array:');
+      write('int32array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
     _float32array: function(arr){

--- a/test/index.js
+++ b/test/index.js
@@ -323,4 +323,12 @@ describe('hash', function() {
       assert.equal(ha, hb, 'Hashing should not respect the order of Set entries');
     });
   }
+
+  if (typeof Uint8Array !== 'undefined') {
+    it('respects typed array\'s types', function () {
+      assert.notEqual(hash(new Int8Array([1,2,3,4])), hash(new Uint8Array([1,2,3,4])), 'Hashing should respect signed / unsigned Int8Array type');
+      assert.notEqual(hash(new Int16Array([1,2,3,4])), hash(new Uint16Array([1,2,3,4])), 'Hashing should respect signed / unsigned Int16Array type');
+      assert.notEqual(hash(new Int32Array([1,2,3,4])), hash(new Uint32Array([1,2,3,4])), 'Hashing should respect signed / unsigned Int32Array type');
+    });
+  }
 });


### PR DESCRIPTION
This PR:
- Fixes typo in _int8array, _int16array and _int32array hashing functions.
- Adds tests to ensure that hashing function respect's different typed arrays types.

Closes #113 