### PR TITLE
perf: object hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,13 +104,16 @@ function applyDefaults(object, sourceOptions){
   return options;
 }
 
+var nativeFunc = '[native code] }';
+var nativeFuncLength = nativeFunc.length;
+
 /** Check if the given function is a native function */
 function isNativeFunction(f) {
   if ((typeof f) !== 'function') {
     return false;
   }
-  var exp = /^function\s+\w*\s*\(\s*\)\s*{\s+\[native code\]\s+}$/i;
-  return exp.exec(Function.prototype.toString.call(f)) != null;
+
+  return Function.prototype.toString.call(f).slice(-nativeFuncLength) === nativeFunc;
 }
 
 function hash(object, options) {

--- a/index.js
+++ b/index.js
@@ -54,9 +54,11 @@ exports.keysMD5 = function(object){
 };
 
 // Internals
-var hashes = crypto.getHashes ? crypto.getHashes().slice() : ['sha1', 'md5'];
+var hashes = crypto.getHashes ? crypto.getHashes().slice().map(hash => hash.toLowerCase()) : ['sha1', 'md5'];
 hashes.push('passthrough');
+var hashesMap = new Map(hashes.map(hash => [hash, true]));
 var encodings = ['buffer', 'hex', 'binary', 'base64'];
+var encodingsMap = new Map(encodings.map(encoding => [encoding, true]));
 
 function applyDefaults(object, sourceOptions){
   sourceOptions = sourceOptions || {};
@@ -84,18 +86,13 @@ function applyDefaults(object, sourceOptions){
 
   // if there is a case-insensitive match in the hashes list, accept it
   // (i.e. SHA256 for sha256)
-  for (var i = 0; i < hashes.length; ++i) {
-    if (hashes[i].toLowerCase() === options.algorithm.toLowerCase()) {
-      options.algorithm = hashes[i];
-    }
-  }
-
-  if(hashes.indexOf(options.algorithm) === -1){
+  if (hashesMap.has(options.algorithm.toLowerCase()))
+    options.algorithm = options.algorithm.toLowerCase();
+  else
     throw new Error('Algorithm "' + options.algorithm + '"  not supported. ' +
       'supported values: ' + hashes.join(', '));
-  }
 
-  if(encodings.indexOf(options.encoding) === -1 &&
+  if(!encodingsMap.has(options.encoding) &&
      options.algorithm !== 'passthrough'){
     throw new Error('Encoding "' + options.encoding + '"  not supported. ' +
       'supported values: ' + encodings.join(', '));

--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ function typeHasher(options, writeTo, context){
       return this.array(entries, false);
     },
     date: function(date){
-      return write('date:' + date.toJSON());
+      return write('date:' + date.valueOf());
     },
     symbol: function(sym){
       return write('symbol:' + sym.toString());

--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ var crypto = require('crypto');
 exports = module.exports = objectHash;
 
 function objectHash(object, options){
-  options = applyDefaults(object, options);
-
-  return hash(object, options);
+  return hash(object, applyDefaults(object, options));
 }
 
 /**
@@ -60,27 +58,43 @@ var hashesMap = new Map(hashes.map(hash => [hash, true]));
 var encodings = ['buffer', 'hex', 'binary', 'base64'];
 var encodingsMap = new Map(encodings.map(encoding => [encoding, true]));
 
+var defaultOptions = {
+  algorithm: 'sha1',
+  encoding: 'hex',
+  excludeValues: false,
+  ignoreUnknown: false,
+  respectType: true,
+  respectFunctionNames: true,
+  respectFunctionProperties: true,
+  unorderedArrays: false,
+  unorderedSets: true,
+  unorderedObjects: true,
+  replacer: undefined,
+  excludeKeys: undefined,
+};
+
 function applyDefaults(object, sourceOptions){
-  var userOptions = sourceOptions || {};
-
-  var options = {
-    algorithm: userOptions.algorithm ? userOptions.algorithm.toLowerCase() : 'sha1',
-    encoding: userOptions.encoding ? userOptions.encoding.toLowerCase() : 'hex',
-    excludeValues: userOptions.excludeValues ? true : false,
-    ignoreUnknown: userOptions.ignoreUnknown !== true ? false : true, // default to false
-    respectType: userOptions.respectType === false ? false : true, // default to true
-    respectFunctionNames: userOptions.respectFunctionNames === false ? false : true,
-    respectFunctionProperties: userOptions.respectFunctionProperties === false ? false : true,
-    unorderedArrays: userOptions.unorderedArrays !== true ? false : true, // default to false
-    unorderedSets: userOptions.unorderedSets === false ? false : true, // default to false
-    unorderedObjects: userOptions.unorderedObjects === false ? false : true, // default to true
-    replacer: userOptions.replacer || undefined,
-    excludeKeys: userOptions.excludeKeys || undefined,
-  };
-
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');
   }
+
+  if (!sourceOptions)
+    return defaultOptions;
+
+  var options = {
+    algorithm: sourceOptions.algorithm ? sourceOptions.algorithm.toLowerCase() : 'sha1',
+    encoding: sourceOptions.encoding ? sourceOptions.encoding.toLowerCase() : 'hex',
+    excludeValues: sourceOptions.excludeValues ? true : false,
+    ignoreUnknown: sourceOptions.ignoreUnknown !== true ? false : true, // default to false
+    respectType: sourceOptions.respectType === false ? false : true, // default to true
+    respectFunctionNames: sourceOptions.respectFunctionNames === false ? false : true,
+    respectFunctionProperties: sourceOptions.respectFunctionProperties === false ? false : true,
+    unorderedArrays: sourceOptions.unorderedArrays !== true ? false : true, // default to false
+    unorderedSets: sourceOptions.unorderedSets === false ? false : true, // default to true
+    unorderedObjects: sourceOptions.unorderedObjects === false ? false : true, // default to true
+    replacer: sourceOptions.replacer || undefined,
+    excludeKeys: sourceOptions.excludeKeys || undefined,
+  };
 
   // if there is a case-insensitive match in the hashes list, accept it
   // (i.e. SHA256 for sha256)

--- a/index.js
+++ b/index.js
@@ -190,9 +190,9 @@ function typeHasher(options, writeTo, context){
 
       //console.log("[DEBUG] Dispatch: ", value, "->", type, " -> ", "_" + type);
 
-      return this['_' + type](value);
+      return this[type](value);
     },
-    _object: function(object) {
+    object: function(object) {
       var objString = Object.prototype.toString.call(object);
 
       var objType = '';
@@ -221,8 +221,8 @@ function typeHasher(options, writeTo, context){
       }
 
       if(objType !== 'object' && objType !== 'function' && objType !== 'asyncfunction') {
-        if(this['_' + objType]) {
-          this['_' + objType](object);
+        if(this[objType]) {
+          this[objType](object);
         } else if (options.ignoreUnknown) {
           return write('[' + objType + ']');
         } else {
@@ -260,7 +260,7 @@ function typeHasher(options, writeTo, context){
         });
       }
     },
-    _array: function(arr, unordered){
+    array: function(arr, unordered){
       unordered = typeof unordered !== 'undefined' ? unordered :
         options.unorderedArrays !== false; // default to options.unorderedArrays
 
@@ -293,25 +293,25 @@ function typeHasher(options, writeTo, context){
       });
       context = context.concat(contextAdditions);
       entries.sort();
-      return this._array(entries, false);
+      return this.array(entries, false);
     },
-    _date: function(date){
+    date: function(date){
       return write('date:' + date.toJSON());
     },
-    _symbol: function(sym){
+    symbol: function(sym){
       return write('symbol:' + sym.toString());
     },
-    _error: function(err){
+    error: function(err){
       return write('error:' + err.toString());
     },
-    _boolean: function(bool){
+    boolean: function(bool){
       return write('bool:' + bool.toString());
     },
-    _string: function(string){
+    string: function(string){
       write('string:' + string.length + ':');
       write(string.toString());
     },
-    _function: function(fn){
+    function: function(fn){
       write('fn:');
       if (isNativeFunction(fn)) {
         this.dispatch('[native]');
@@ -327,82 +327,82 @@ function typeHasher(options, writeTo, context){
       }
 
       if (options.respectFunctionProperties) {
-        this._object(fn);
+        this.object(fn);
       }
     },
-    _number: function(number){
+    number: function(number){
       return write('number:' + number.toString());
     },
-    _xml: function(xml){
+    xml: function(xml){
       return write('xml:' + xml.toString());
     },
-    _null: function() {
+    null: function() {
       return write('Null');
     },
-    _undefined: function() {
+    undefined: function() {
       return write('Undefined');
     },
-    _regexp: function(regex){
+    regexp: function(regex){
       return write('regex:' + regex.toString());
     },
-    _uint8array: function(arr){
+    uint8array: function(arr){
       write('uint8array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _uint8clampedarray: function(arr){
+    uint8clampedarray: function(arr){
       write('uint8clampedarray:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _int8array: function(arr){
+    int8array: function(arr){
       write('int8array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _uint16array: function(arr){
+    uint16array: function(arr){
       write('uint16array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _int16array: function(arr){
+    int16array: function(arr){
       write('int16array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _uint32array: function(arr){
+    uint32array: function(arr){
       write('uint32array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _int32array: function(arr){
+    int32array: function(arr){
       write('int32array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _float32array: function(arr){
+    float32array: function(arr){
       write('float32array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _float64array: function(arr){
+    float64array: function(arr){
       write('float64array:');
       return this.dispatch(Array.prototype.slice.call(arr));
     },
-    _arraybuffer: function(arr){
+    arraybuffer: function(arr){
       write('arraybuffer:');
       return this.dispatch(new Uint8Array(arr));
     },
-    _url: function(url) {
+    url: function(url) {
       return write('url:' + url.toString(), 'utf8');
     },
-    _map: function(map) {
+    map: function(map) {
       write('map:');
       var arr = Array.from(map);
-      return this._array(arr, options.unorderedSets !== false);
+      return this.array(arr, options.unorderedSets !== false);
     },
-    _set: function(set) {
+    set: function(set) {
       write('set:');
       var arr = Array.from(set);
-      return this._array(arr, options.unorderedSets !== false);
+      return this.array(arr, options.unorderedSets !== false);
     },
-    _file: function(file) {
+    file: function(file) {
       write('file:');
       return this.dispatch([file.name, file.size, file.type, file.lastModfied]);
     },
-    _blob: function() {
+    blob: function() {
       if (options.ignoreUnknown) {
         return write('[blob]');
       }
@@ -411,28 +411,28 @@ function typeHasher(options, writeTo, context){
         '(see https://github.com/puleos/object-hash/issues/26)\n' +
         'Use "options.replacer" or "options.ignoreUnknown"\n');
     },
-    _domwindow: function() { return write('domwindow'); },
-    _bigint: function(number){
+    domwindow: function() { return write('domwindow'); },
+    bigint: function(number){
       return write('bigint:' + number.toString());
     },
     /* Node.js standard native objects */
-    _process: function() { return write('process'); },
-    _timer: function() { return write('timer'); },
-    _pipe: function() { return write('pipe'); },
-    _tcp: function() { return write('tcp'); },
-    _udp: function() { return write('udp'); },
-    _tty: function() { return write('tty'); },
-    _statwatcher: function() { return write('statwatcher'); },
-    _securecontext: function() { return write('securecontext'); },
-    _connection: function() { return write('connection'); },
-    _zlib: function() { return write('zlib'); },
-    _context: function() { return write('context'); },
-    _nodescript: function() { return write('nodescript'); },
-    _httpparser: function() { return write('httpparser'); },
-    _dataview: function() { return write('dataview'); },
-    _signal: function() { return write('signal'); },
-    _fsevent: function() { return write('fsevent'); },
-    _tlswrap: function() { return write('tlswrap'); },
+    process: function() { return write('process'); },
+    timer: function() { return write('timer'); },
+    pipe: function() { return write('pipe'); },
+    tcp: function() { return write('tcp'); },
+    udp: function() { return write('udp'); },
+    tty: function() { return write('tty'); },
+    statwatcher: function() { return write('statwatcher'); },
+    securecontext: function() { return write('securecontext'); },
+    connection: function() { return write('connection'); },
+    zlib: function() { return write('zlib'); },
+    context: function() { return write('context'); },
+    nodescript: function() { return write('nodescript'); },
+    httpparser: function() { return write('httpparser'); },
+    dataview: function() { return write('dataview'); },
+    signal: function() { return write('signal'); },
+    fsevent: function() { return write('fsevent'); },
+    tlswrap: function() { return write('tlswrap'); },
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -61,24 +61,22 @@ var encodings = ['buffer', 'hex', 'binary', 'base64'];
 var encodingsMap = new Map(encodings.map(encoding => [encoding, true]));
 
 function applyDefaults(object, sourceOptions){
-  sourceOptions = sourceOptions || {};
+  var userOptions = sourceOptions || {};
 
-  // create a copy rather than mutating
-  var options = {};
-  options.algorithm = sourceOptions.algorithm || 'sha1';
-  options.encoding = sourceOptions.encoding || 'hex';
-  options.excludeValues = sourceOptions.excludeValues ? true : false;
-  options.algorithm = options.algorithm.toLowerCase();
-  options.encoding = options.encoding.toLowerCase();
-  options.ignoreUnknown = sourceOptions.ignoreUnknown !== true ? false : true; // default to false
-  options.respectType = sourceOptions.respectType === false ? false : true; // default to true
-  options.respectFunctionNames = sourceOptions.respectFunctionNames === false ? false : true;
-  options.respectFunctionProperties = sourceOptions.respectFunctionProperties === false ? false : true;
-  options.unorderedArrays = sourceOptions.unorderedArrays !== true ? false : true; // default to false
-  options.unorderedSets = sourceOptions.unorderedSets === false ? false : true; // default to false
-  options.unorderedObjects = sourceOptions.unorderedObjects === false ? false : true; // default to true
-  options.replacer = sourceOptions.replacer || undefined;
-  options.excludeKeys = sourceOptions.excludeKeys || undefined;
+  var options = {
+    algorithm: userOptions.algorithm ? userOptions.algorithm.toLowerCase() : 'sha1',
+    encoding: userOptions.encoding ? userOptions.encoding.toLowerCase() : 'hex',
+    excludeValues: userOptions.excludeValues ? true : false,
+    ignoreUnknown: userOptions.ignoreUnknown !== true ? false : true, // default to false
+    respectType: userOptions.respectType === false ? false : true, // default to true
+    respectFunctionNames: userOptions.respectFunctionNames === false ? false : true,
+    respectFunctionProperties: userOptions.respectFunctionProperties === false ? false : true,
+    unorderedArrays: userOptions.unorderedArrays !== true ? false : true, // default to false
+    unorderedSets: userOptions.unorderedSets === false ? false : true, // default to false
+    unorderedObjects: userOptions.unorderedObjects === false ? false : true, // default to true
+    replacer: userOptions.replacer || undefined,
+    excludeKeys: userOptions.excludeKeys || undefined,
+  };
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');

--- a/index.js
+++ b/index.js
@@ -193,14 +193,17 @@ function typeHasher(options, writeTo, context){
       return this['_' + type](value);
     },
     _object: function(object) {
-      var pattern = (/\[object (.*)\]/i);
       var objString = Object.prototype.toString.call(object);
-      var objType = pattern.exec(objString);
-      if (!objType) { // object type did not match [object ...]
+
+      var objType = '';
+      var objectLength = objString.length;
+
+      // '[object a]'.length === 10, the minimum
+      if (objectLength < 10)
         objType = 'unknown:[' + objString + ']';
-      } else {
-        objType = objType[1]; // take only the class name
-      }
+      else
+        // '[object '.length === 8
+        objType = objString.slice(8, objectLength - 1)
 
       objType = objType.toLowerCase();
 

--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ function typeHasher(options, writeTo, context){
         hasher.dispatch(entry);
         // take only what was added to localContext and append it to contextAdditions
         contextAdditions = contextAdditions.concat(localContext.slice(context.length));
-        return strm.read().toString();
+        return strm.read();
       });
       context = context.concat(contextAdditions);
       entries.sort();
@@ -305,11 +305,10 @@ function typeHasher(options, writeTo, context){
       return write('error:' + err.toString());
     },
     boolean: function(bool){
-      return write('bool:' + bool.toString());
+      return write('bool:' + bool);
     },
     string: function(string){
-      write('string:' + string.length + ':');
-      write(string.toString());
+      write('string:' + string.length + ':' + string);
     },
     function: function(fn){
       write('fn:');
@@ -331,7 +330,7 @@ function typeHasher(options, writeTo, context){
       }
     },
     number: function(number){
-      return write('number:' + number.toString());
+      return write('number:' + number);
     },
     xml: function(xml){
       return write('xml:' + xml.toString());


### PR DESCRIPTION
Hello! 

Inspired by a issue at https://github.com/nestjs/nest/issues/10844, I did a performance analysis in this library and here what I have found:

### perf: faster isNativeFunction check

This one was very fun to discover, I didn't expect that the simple validation could work and it was so fast compare to the original version.

```
'oldRegex x 13,961,935 ops/sec ±2.56% (83 runs sampled)',
'endsWith x 43,583,325 ops/sec ±0.46% (94 runs sampled)',
'slice x 1,133,185,926 ops/sec ±0.59% (93 runs sampled)',
'for x 160,559,673 ops/sec ±0.15% (93 runs sampled)'
```

> Benchmark: [bench-is-native-function.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-is-native-function-js)

### perf: faster extract object type from toString

Inspired by the previous improvement, I did't the same here.

```
'oldRegex x 12,546,910 ops/sec ±2.65% (81 runs sampled)',
'slice x 1,135,283,250 ops/sec ±0.30% (97 runs sampled)'
```

> Benchmark: [bench-object-type.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-object-type-js)

### perf: faster object access by avoid string concat

This one, V8 from what I could understand can predict when the same pattern is happening, but when we insert some randomness, the performance of string concatening is a little bit worse.

```
'oldObjectAccess x 1,141,640,736 ops/sec ±0.53% (97 runs sampled)',
'newObjectAccess x 1,146,221,890 ops/sec ±0.33% (97 runs sampled)',
'random: oldObjectAccess x 9,099,441 ops/sec ±1.14% (92 runs sampled)',
'random: newObjectAccess x 23,251,465 ops/sec ±1.63% (88 runs sampled)'
```

> Benchmark: [bench-object-access.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-object-access-js)

###  perf: avoid toString when we know that the value is already a string

I did some tests and some values are fast by just leaving `'string' + value`, other values are slow, so I only change the values that shows a significant improvement.

```
'with toString x 243,790,997 ops/sec ±4.95% (88 runs sampled)',
'without toString x 1,138,995,770 ops/sec ±0.12% (94 runs sampled)',
'bool: with toString x 222,584,175 ops/sec ±0.11% (97 runs sampled)',
'bool: without toString x 1,142,979,415 ops/sec ±0.46% (94 runs sampled)',
'number: with toString x 110,618,185 ops/sec ±0.48% (94 runs sampled)',
'number: without toString x 1,148,295,991 ops/sec ±0.05% (99 runs sampled)',
'url: with toString x 11,248,050 ops/sec ±1.76% (84 runs sampled)',
'url: without toString x 4,678,286 ops/sec ±0.95% (94 runs sampled)',
'bigint: with toString x 24,012,147 ops/sec ±1.97% (87 runs sampled)',
'bigint: without toString x 15,661,883 ops/sec ±2.36% (78 runs sampled)'
```

> Benchmark: [bench-to-string.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-to-string-js)

Until here, we gain some performance improvements, like:

```
'hash(largeJson) x 0.97 ops/sec ±0.57% (7 runs sampled)',
'objectHash(largeJson, { unorderedObjects: true }) x 0.97 ops/sec ±0.99% (7 runs sampled)',
'fasterObjectHash(largeJson) x 1.14 ops/sec ±0.42% (7 runs sampled)',
'fasterObjectHash(largeJson, { unorderedObjects: true }) x 1.15 ops/sec ±1.06% (7 runs sampled)'
```

### perf: faster circular checking by using map

By far, this is the greatest optimization, using `Map` instead using `Array` speed-up this library a lot.

```
'hash(largeJson) x 1.02 ops/sec ±2.25% (7 runs sampled)',
'objectHash(largeJson, { unorderedObjects: true }) x 1.02 ops/sec ±0.92% (7 runs sampled)',
'fasterObjectHash(largeJson) x 2.12 ops/sec ±0.46% (10 runs sampled)',
'fasterObjectHash(largeJson, { unorderedObjects: true }) x 2.12 ops/sec ±0.12% (10 runs sampled)'
```

> Benchmark: [bench.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-js)

### perf: avoid splice method to insert values

For this one, I did some benchmarks but I was not happy with the results:

```
'splice x 8,139,878 ops/sec ±1.25% (89 runs sampled)',
'unshift x 7,932,324 ops/sec ±0.97% (94 runs sampled)',
'Array.prototype.push.apply x 14,664,082 ops/sec ±1.09% (90 runs sampled)'
```

> Benchmark: [bench-splice-vs-push-js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-splice-vs-push-js)

So, instead of doing some array manipulation, I just create another one and run it when needed.

The improvement was very light, I could only see when I profile, first the previous version:

```
Statistical profiling result from 01-stress-v8.log, (4823 ticks, 3 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
   4310   89.4%          /home/h4ad/.asdf/installs/nodejs/19.3.0/bin/node
    140    2.9%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
```

> [01-stress-v8.txt](https://github.com/puleos/object-hash/files/10419599/01-stress-v8.txt)

Then, it becomes:

```
Statistical profiling result from 01-stress-v10.log, (4714 ticks, 6 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
   4200   89.1%          /home/h4ad/.asdf/installs/nodejs/19.3.0/bin/node
    114    2.4%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      1    0.0%          [vdso]
      1    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
```

> [01-stress-v10.txt](https://github.com/puleos/object-hash/files/10419602/01-stress-v10.txt)

### perf: use valueOf instead toJSON

This one could be a breaking change because it changes the hashes.

Instead using `toJSON` and printing a ISOString, I just use `valueOf` which returns the Unix Time, which is waaay faster than `toJSON`:

```
'toJSON x 624,769 ops/sec ±0.69% (86 runs sampled)',
'valueOf x 275,753,257 ops/sec ±0.68% (93 runs sampled)',
'+date x 13,073,897 ops/sec ±0.56% (95 runs sampled)'
```

> Benchmark: [bench-date-tojson-vs-value-of-js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-date-tojson-vs-value-of-js)

### perf: faster lookup for valid algorithm and encoding

This one brings some improvements when you need to instantiate a lot the `object-hash`, see:

```
'hash({}) x 43,899 ops/sec ±0.83% (88 runs sampled)',
'fasterObjectHash({}) x 66,115 ops/sec ±0.47% (94 runs sampled)',
'hash(largeJson) x 0.97 ops/sec ±0.59% (7 runs sampled)',
'objectHash(largeJson, { unorderedObjects: true }) x 0.97 ops/sec ±0.77% (7 runs sampled)',
'fasterObjectHash(largeJson) x 2.15 ops/sec ±1.14% (10 runs sampled)',
'fasterObjectHash(largeJson, { unorderedObjects: true }) x 2.15 ops/sec ±1.36% (10 runs sampled)'
```

> Benchmark: [bench.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-js)

### perf: avoid mutate options object by adding new properties

This one I tend to do because of hidden classes of v8, it didn't bring any significant performance improvements but I think that is good to avoid mutate objects.

Also, I tend to avoid to mutate arguments too because of: https://github.com/NathanaelA/v8-Natives/blob/master/opti-killers.md#3-managing-arguments

### perf: using passThrough always instead crypto

This one is another optimization that brings the library to another level, instead call `crypto.update` every time, I only will call in the end with the huge chunk of string.

Before:

```
'hash({}) x 44,387 ops/sec ±0.47% (89 runs sampled)',
'fasterObjectHash({}) x 69,483 ops/sec ±0.37% (96 runs sampled)',
'hash(singleObject) x 19,579 ops/sec ±0.64% (97 runs sampled)',
'fasterObjectHash(singleObject) x 29,945 ops/sec ±0.36% (96 runs sampled)',
'hash(tinyArray) x 2,730 ops/sec ±0.35% (95 runs sampled)',
'fasterObjectHash(tinyArray) x 3,992 ops/sec ±0.61% (93 runs sampled)',
'hash(mediumArray) x 279 ops/sec ±1.12% (87 runs sampled)',
'fasterObjectHash(mediumArray) x 418 ops/sec ±0.08% (90 runs sampled)',
'hash(largeArray) x 24.11 ops/sec ±0.59% (44 runs sampled)',
'fasterObjectHash(largeArray) x 41.20 ops/sec ±0.93% (55 runs sampled)',
'hash(largeJson) x 1.00 ops/sec ±0.56% (7 runs sampled)',
'objectHash(largeJson, { unorderedObjects: true }) x 1.00 ops/sec ±0.21% (7 runs sampled)',
'fasterObjectHash(largeJson) x 2.09 ops/sec ±0.51% (10 runs sampled)',
'fasterObjectHash(largeJson, { unorderedObjects: true }) x 2.08 ops/sec ±0.61% (10 runs sampled)'
```

After:

```
'hash({}) x 43,767 ops/sec ±1.32% (95 runs sampled)',
'fasterObjectHash({}) x 117,922 ops/sec ±0.78% (93 runs sampled)',
'hash(singleObject) x 19,378 ops/sec ±1.02% (89 runs sampled)',
'fasterObjectHash(singleObject) x 61,093 ops/sec ±0.79% (97 runs sampled)',
'hash(tinyArray) x 2,689 ops/sec ±0.98% (93 runs sampled)',
'fasterObjectHash(tinyArray) x 9,589 ops/sec ±0.84% (93 runs sampled)',
'hash(mediumArray) x 281 ops/sec ±0.69% (88 runs sampled)',
'fasterObjectHash(mediumArray) x 985 ops/sec ±1.20% (93 runs sampled)',
'hash(largeArray) x 23.78 ops/sec ±0.54% (43 runs sampled)',
'fasterObjectHash(largeArray) x 74.40 ops/sec ±1.77% (64 runs sampled)',
'hash(largeJson) x 0.99 ops/sec ±0.38% (7 runs sampled)',
'objectHash(largeJson, { unorderedObjects: true }) x 0.99 ops/sec ±1.47% (7 runs sampled)',
'fasterObjectHash(largeJson) x 1.77 ops/sec ±5.14% (9 runs sampled)',
'fasterObjectHash(largeJson, { unorderedObjects: true }) x 1.89 ops/sec ±2.89% (9 runs sampled)'
```

> Benchmark: [bench.js](https://gist.github.com/H4ad/0c8b3816ccf3de1506095f7257f62816#file-bench-js)

With this modification, we went from about 40-70% of improvement to 200-250% in normal cases, for large objects, the improvement will vary but it shows up to 70%-80%.