### PR TITLE
feat: add base64url encoding option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var crypto = require('crypto');
  *
  *  - `algorithm` hash algo to be used by this instance: *'sha1', 'md5'
  *  - `excludeValues` {true|*false} hash object keys, values ignored
- *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64'
+ *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64', 'base64url'
  *  - `ignoreUnknown` {true|*false} ignore unknown object types
  *  - `replacer` optional function that replaces values before hashing
  *  - `respectFunctionProperties` {*true|false} consider function properties when hashing
@@ -56,7 +56,7 @@ exports.keysMD5 = function(object){
 // Internals
 var hashes = crypto.getHashes ? crypto.getHashes().slice() : ['sha1', 'md5'];
 hashes.push('passthrough');
-var encodings = ['buffer', 'hex', 'binary', 'base64'];
+var encodings = ['buffer', 'hex', 'binary', 'base64', 'base64url'];
 
 function applyDefaults(object, sourceOptions){
   sourceOptions = sourceOptions || {};

--- a/readme.markdown
+++ b/readme.markdown
@@ -36,7 +36,7 @@ Generate a hash from any object or type.  Defaults to sha1 with hex encoding.
   * This supports the algorithms returned by `crypto.getHashes()`. Note that the default of SHA-1 is not considered secure, and a stronger algorithm should be used if a cryptographical hash is desired.
   * This also supports the `passthrough` algorith, which will return the information that would otherwise have been hashed.
 * `excludeValues` {true|false} hash object keys, values ignored. default: false
-* `encoding` hash encoding, supports 'buffer', 'hex', 'binary', 'base64'. default: hex
+* `encoding` hash encoding, supports 'buffer', 'hex', 'binary', 'base64', 'base64url'. default: hex
 * `ignoreUnknown` {true|*false} ignore unknown object types. default: false
 * `replacer` optional function that replaces values before hashing. default: accept all values
 * `respectFunctionProperties` {true|false} Whether properties on functions are considered when hashing. default: true


### PR DESCRIPTION
This just allows to pass through 'base64url' to the node digest functions since they natively support base64url.

closes #69