### PR TITLE
Support for Excluding Keys in Nested Objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,8 @@ function typeHasher(options, writeTo, context){
     }
   };
 
+  var keysPath = [];
+
   return {
     dispatch: function(value){
       if (options.replacer) {
@@ -193,6 +195,7 @@ function typeHasher(options, writeTo, context){
       var pattern = (/\[object (.*)\]/i);
       var objString = Object.prototype.toString.call(object);
       var objType = pattern.exec(objString);
+      var baseKeysPath = [...keysPath];
       if (!objType) { // object type did not match [object ...]
         objType = 'unknown:[' + objString + ']';
       } else {
@@ -239,12 +242,14 @@ function typeHasher(options, writeTo, context){
         }
 
         if (options.excludeKeys) {
-          keys = keys.filter(function(key) { return !options.excludeKeys(key); });
+          keys = keys.filter(function(key) { return !options.excludeKeys(key, [...keysPath, key]); });
         }
 
         write('object:' + keys.length + ':');
         var self = this;
         return keys.forEach(function(key){
+          keysPath = [...baseKeysPath, key];
+
           self.dispatch(key);
           write(':');
           if(!options.excludeValues) {
@@ -257,11 +262,16 @@ function typeHasher(options, writeTo, context){
     _array: function(arr, unordered){
       unordered = typeof unordered !== 'undefined' ? unordered :
         options.unorderedArrays !== false; // default to options.unorderedArrays
-
+      var baseKeysPath = [...keysPath];
+      
+      if (options.excludeKeys) 
+        arr = arr.filter((entry, index) => !options.excludeKeys(null, [...baseKeysPath, index]))
+      
       var self = this;
       write('array:' + arr.length + ':');
       if (!unordered || arr.length <= 1) {
-        return arr.forEach(function(entry) {
+        return arr.forEach(function(entry, index) {
+          keysPath = [...baseKeysPath, index];
           return self.dispatch(entry);
         });
       }

--- a/test/index.js
+++ b/test/index.js
@@ -304,6 +304,36 @@ describe('hash', function() {
     assert.equal(ha, hb, 'Hashing should ignore key `b`');
   });
 
+  it('excludeKeys path works', function() {
+    var ha, hb, hc;
+    ha = hash({a: 1, b: 4, c:{a:5, b:6}}, { excludeKeys: function(key, keyPath) { return keyPath.join(".") == "c.b" } });
+    hb = hash({a: 1, b: 4, c:{a:5}});
+    hc = hash({a: 1, b: 4, c:{}});
+
+    assert.equal(ha, hb, 'Hashing should ignore key `c.b`');
+    assert.notEqual(hb, hc, 'Hash get sub difference');
+  });
+
+  it('excludeKeys path collection works', function() {
+    var ha, hb, hc;
+    ha = hash({a: 1, b: 4, c:[{a:2, b:3},{a:5, b:6}]}, { excludeKeys: function(key, keyPath) { return keyPath.join(".") == "c.1.b" } });
+    hb = hash({a: 1, b: 4, c:[{a:2, b:3},{a:5}]});
+    hc = hash({a: 1, b: 4, c:[{}]});
+
+    assert.equal(ha, hb, 'Hashing should ignore key `c.1.b`');
+    assert.notEqual(hb, hc, 'Hash get sub difference');
+  });
+
+  it('excludeKeys path array works', function() {
+    var ha, hb, hc;
+    ha = hash({a: 1, b: 4, c:[{a:2, b:3},{a:5, b:6}]}, { excludeKeys: function(key, keyPath) { return keyPath.join(".") == "c.1" } });
+    hb = hash({a: 1, b: 4, c:[{a:2, b:3}]});
+    hc = hash({a: 1, b: 4, c:[{}]});
+
+    assert.equal(ha, hb, 'Hashing should ignore key `c.1.b`');
+    assert.notEqual(hb, hc, 'Hash get sub difference');
+  });
+
   if (typeof Set !== 'undefined') {
     it('unorderedSets = false', function() {
       var opt = { unorderedSets: false };


### PR DESCRIPTION
This commit aims to add the feature of excluding keys in nested objects to the Object-Hash project. The project allows generating hashes from objects.

These modifications enhance the functionality by allowing the exclusion of specific keys in nested objects and arrays. This provides greater flexibility in hash generation and facilitates control over the keys included in the serialization process.

The pull request also includes new test cases to validate the exclusion of keys based on their paths.

#70 