### PR TITLE
Fix tests broken in newer versions of Node.js

### DIFF
--- a/test/blob.js
+++ b/test/blob.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert');
 var hash = require('../index');
+var validSha1 = /^[0-9a-f]{40}$/i;
 
 if (typeof Blob !== 'undefined') {
 describe('hash()ing Blob objects', function() {
@@ -71,7 +72,7 @@ describe('hashing Blob() objects', function() {
       type: 'application/octet-stream',
       lastModified: 100000
     }));
-    var hash2 = hash(new File(new Uint8Array([1,2,3]), 'bar', {
+    var hash2 = hash(new File(new Uint8Array([1,2,3]), 'foo', {
       type: 'application/octet-stream',
       lastModified: 100000
     }));


### PR DESCRIPTION
Fixes some of the tests so that they will pass when running against newer versions of Node.js. This will be useful later when I will add some code to do CI. These test were failing on Node.js 18+, as the `Blob` object [started getting exposed](https://nodejs.org/en/blog/announcements/v18-release-announce#other-global-apis) in that version, before the conditional present in this test was never triggered.