### PR TITLE
Replace deprecated `prepublish` script with `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "test": "node ./node_modules/.bin/mocha test",
-    "prepublish": "gulp dist"
+    "prepublishOnly": "gulp dist"
   },
   "author": "Scott Puleo <puleos@gmail.com>",
   "files": [


### PR DESCRIPTION
Replaces the [deprecated](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts) `prepublish` script with `prepublishOnly`, which will only run when the package is published using `npm publish`.