### PR TITLE
Remove unused `gulp-exec` dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
 
 var gulp = require('gulp');
 var jshint = require('gulp-jshint');
-var exec = require('gulp-exec');
 var stylish = require('jshint-stylish');
 var browserify = require('gulp-browserify');
 var uglify = require('gulp-uglify');

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "gulp": "^4.0.0",
         "gulp-browserify": "^0.5.1",
         "gulp-coveralls": "^0.1.4",
-        "gulp-exec": "^3.0.1",
         "gulp-istanbul": "^1.1.3",
         "gulp-jshint": "^2.0.0",
         "gulp-mocha": "^5.0.0",
@@ -4676,17 +4675,6 @@
         "node": ">= 0.9"
       }
     },
-    "node_modules/gulp-exec": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-exec/-/gulp-exec-3.0.2.tgz",
-      "integrity": "sha512-74sde0n+pQo/Jbe5qsk0sPC4afjnB7VHDUZd4BrRTLt6lsNU451N+kSvCOoSn6q0iqS9ztT1uy8ZE/FRqmXKeQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash.template": "^4.4.0",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.3"
-      }
-    },
     "node_modules/gulp-istanbul": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-1.1.3.tgz",
@@ -7169,37 +7157,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==",
-      "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.template/node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings/node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
       "dev": true
     },
     "node_modules/lodash.values": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "gulp": "^4.0.0",
     "gulp-browserify": "^0.5.1",
     "gulp-coveralls": "^0.1.4",
-    "gulp-exec": "^3.0.1",
     "gulp-istanbul": "^1.1.3",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^5.0.0",


### PR DESCRIPTION
Removes `gulp-exec` from the dependencies, which doesn't seem to be used anywhere.