### PR TITLE
Fix faulty badge for CI in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -6,7 +6,7 @@ as well as custom streams (e.g. CRC32).
 
 [![NPM](https://nodei.co/npm/object-hash.png?downloads=true&downloadRank=true)](https://www.npmjs.com/package/object-hash)
 
-[![GitHub CI](https://github.com/github/puleos/object-hash/workflows/main.yml/badge.svg)](https://github.com/jpuleos/object-hash/actions/workflows/main.yml)
+[![CI](https://github.com/puleos/object-hash/actions/workflows/main.yml/badge.svg)](https://github.com/puleos/object-hash/actions/workflows/main.yml)
 [![Coverage Status](https://coveralls.io/repos/puleos/object-hash/badge.svg?branch=master&service=github)](https://coveralls.io/github/puleos/object-hash?branch=master)
 
 * Hash values of any type.


### PR DESCRIPTION
Looks like I made some typos when creating the GitHub Actions CI badge, this should fix that.