### PR TITLE
Exclude `coverage` directory from ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@
 module.exports = {
   extends: "eslint:recommended",
   ignorePatterns: [
-    "dist"
+    "dist",
+    "coverage"
   ],
   env: {
     node: true,


### PR DESCRIPTION
Forgot to exclude this directory from the linting config.